### PR TITLE
Caution instructors not to share the 'instructor copy' of the submission email with students

### DIFF
--- a/src/main/resources/instructorEmailFragment-instructorCopyPreamble.html
+++ b/src/main/resources/instructorEmailFragment-instructorCopyPreamble.html
@@ -1,5 +1,7 @@
 <p>
   The email below has been sent to students of course: [${courseId}] ${courseName}.
   <br><br>
+  Please do not share this email with students, as it does not contain the link students need to click (which is unique to each student).
+  <br><br>
   === Email message as seen by the students ===
 </p>

--- a/src/main/resources/userEmailTemplate-deadlineExtension.html
+++ b/src/main/resources/userEmailTemplate-deadlineExtension.html
@@ -65,7 +65,8 @@ ${instructorPreamble}
   <ul>
     <li>
       <strong>To ${feedbackAction} your feedback for the above session, please go to this Web address: </strong>
-      <a href="${submitUrl}">${submitUrl}</a>
+      <br>
+      ${submitUrl}
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/main/resources/userEmailTemplate-feedbackSession.html
+++ b/src/main/resources/userEmailTemplate-feedbackSession.html
@@ -54,7 +54,8 @@ ${instructorPreamble}
   <ul>
     <li>
       <strong>To ${feedbackAction} your feedback for the above session, please go to this Web address: </strong>
-      <a href="${submitUrl}">${submitUrl}</a>
+      <br>
+      ${submitUrl}
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
+++ b/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
@@ -54,7 +54,8 @@ ${instructorPreamble}
   <ul>
     <li>
       <strong>To ${feedbackAction} your feedback for the above session, please go to this Web address: </strong>
-      <a href="${submitUrl}">${submitUrl}</a>
+      <br>
+      ${submitUrl}
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/main/resources/userEmailTemplate-feedbackSessionPublished.html
+++ b/src/main/resources/userEmailTemplate-feedbackSessionPublished.html
@@ -32,7 +32,8 @@ ${instructorPreamble}
   <ul>
     <li>
       <strong>To view the responses for this session, please go to this Web address: </strong>
-      <a href="${reportUrl}">${reportUrl}</a>
+      <br>
+      ${reportUrl}
     </li>
     <li>The above link is unique to you. Please do not share it with others.</li>
   </ul>


### PR DESCRIPTION
**Outline of Solution**
- Add a cautionary note to the preamble of instructor email copies to warn instructors not to share their copy with students
- Remove hyperlink from the dummy link placeholder in instructor email copies